### PR TITLE
기존 UDF 방식과 비교를 위한 스파크 내장 함수를 이용한 Sessionization 구현

### DIFF
--- a/src/main/scala/sessionization/SessionizationBuiltIn.scala
+++ b/src/main/scala/sessionization/SessionizationBuiltIn.scala
@@ -1,0 +1,75 @@
+package sessionization
+
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.{Dataset, Encoders, Row, SparkSession}
+
+object SessionizationBuiltIn {
+
+  private val SESSION_EXPIRED_TIME: Int = 30 * 60
+  private val SHA_256 = 256
+
+  private val session: SparkSession = SparkSession
+    .builder()
+    .appName("SessionizationBuiltIn")
+    .master("local[*]")
+    .getOrCreate()
+
+  import session.implicits._
+
+  def main(args: Array[String]): Unit = {
+    // e.g. 2019-10-01
+    val PROCESS_DATE = sys.env("date")
+    // e.g. 00
+    val PROCESS_HOUR = sys.env("hour")
+
+    val df = session.read
+      .schema(Encoders.product[BehaviorSchema].schema)
+      .parquet("../behaviors")
+      .filter($"date_hour" === f"${PROCESS_DATE}T${PROCESS_HOUR}Z")
+      .withColumn(
+        "event_time",
+        to_timestamp($"event_time", "yyyy-MM-dd HH:mm:ss 'UTC'")
+      )
+
+    augmentSessionId(df)
+
+    session.stop()
+  }
+
+  def augmentSessionId(dataset: Dataset[Row]): Dataset[Row] = {
+    val windowSpec = Window.partitionBy("user_id").orderBy("event_time")
+    val eventTimeDiff = unix_timestamp($"event_time") - unix_timestamp(
+      lag($"event_time", 1).over(windowSpec)
+    )
+    val sessionIdentify =
+      sha2(concat_ws("-", $"user_id", $"event_time"), SHA_256)
+
+    // 1. lag 통해 time_diff 컬럼에 현재 event_time, 이전 event_time 차이를 저장
+    // 2. time_diff 가 SESSION_EXPIRED_TIME 초과시 NULL, 첫 시작 event_time 또한 NULL 로 저장
+    val dfWithTimeDiff = dataset
+      .withColumn("time_diff", eventTimeDiff)
+      .withColumn(
+        "time_diff",
+        when($"time_diff" > SESSION_EXPIRED_TIME, null)
+          .otherwise($"time_diff")
+      )
+
+    // 1. 첫 시작 혹은 SESSION_EXPIRED_TIME 초과 ("time_diff".isNull) 일 때, sha2 통해 session_id 를 생성
+    // 2. 나머지의 경우 NULL 저장한 후, last window 통하여 이전의 session_id를 연속되게 부여
+    val dfWithSessionId = dfWithTimeDiff
+      .withColumn(
+        "session_id",
+        when($"time_diff".isNull, sessionIdentify).otherwise(null)
+      )
+      .withColumn(
+        "session_id",
+        last("session_id", ignoreNulls = true)
+          .over(windowSpec.rowsBetween(Window.unboundedPreceding, 0))
+      )
+      .drop("time_diff")
+
+    dfWithSessionId
+  }
+
+}

--- a/src/main/scala/sessionization/SessionizationUdf.scala
+++ b/src/main/scala/sessionization/SessionizationUdf.scala
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.sql.Timestamp
 
-object Sessionization {
+object SessionizationUdf {
 
   private val SESSION_EXPIRED_TIME: Long = 30 * 60 * 1000L
 

--- a/src/test/scala/sessionization/SessionizationUdfTest.scala
+++ b/src/test/scala/sessionization/SessionizationUdfTest.scala
@@ -3,11 +3,11 @@ package sessionization
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, to_timestamp}
 import org.scalatest.flatspec.AnyFlatSpec
-import sessionization.Sessionization.augmentSessionId
+import sessionization.SessionizationUdf.augmentSessionId
 
 import java.sql.Timestamp
 
-class SessionizationTest extends AnyFlatSpec {
+class SessionizationUdfTest extends AnyFlatSpec {
 
   val spark: SparkSession = SparkSession
     .builder()


### PR DESCRIPTION
#3 - 기존 UDF 방식과 스파크 내장 함수를 사용했을 때 Sessionization 성능 비교 하기 위해 SessionizationBuiltIn 를 구현하였습니다.

---

### 반영사항
- SessionizationUdf 명칭 변경 / SessionizationBuiltIn 구현
- 이전 event_time 과 차이 계산 후 Session 의 시작을 결정
- 시작 Session에 session_id 할당, last 를 통하여 나머지 연속된 session_id 부여