### PR TITLE
Continuous Sessionization 구현

### DIFF
--- a/src/main/scala/sessionization/SessionSchema.scala
+++ b/src/main/scala/sessionization/SessionSchema.scala
@@ -1,0 +1,13 @@
+package sessionization
+
+case class SessionSchema(
+    event_time: String,
+    event_type: String,
+    product_id: Long,
+    category_id: Long,
+    category_code: String,
+    brand: String,
+    price: Double,
+    user_id: Long,
+    session_id: String
+)

--- a/src/main/scala/sessionization/SessionizationBuiltIn.scala
+++ b/src/main/scala/sessionization/SessionizationBuiltIn.scala
@@ -13,6 +13,7 @@ object SessionizationBuiltIn {
     .builder()
     .appName("SessionizationBuiltIn")
     .master("local[*]")
+    .config("spark.sql.sources.partitionOverwriteMode", "dynamic")
     .getOrCreate()
 
   import session.implicits._
@@ -32,7 +33,13 @@ object SessionizationBuiltIn {
         to_timestamp($"event_time", "yyyy-MM-dd HH:mm:ss 'UTC'")
       )
 
-    augmentSessionId(df)
+    val sessionDf = augmentSessionId(df)
+
+    sessionDf.write
+      .partitionBy("date_hour")
+      .mode("overwrite")
+      .format("parquet")
+      .save("../sessions")
 
     session.stop()
   }

--- a/src/main/scala/sessionization/SessionizationUdf.scala
+++ b/src/main/scala/sessionization/SessionizationUdf.scala
@@ -7,6 +7,10 @@ import java.nio.charset.StandardCharsets
 import java.security.MessageDigest
 import java.sql.Timestamp
 
+/** 참고: 이 객체는 더 이상 사용되지 않으며, 향후 제거되거나 교체될 수 있습니다.
+  * [https://github.com/f-lab-edu/commerce-sessionization/issues/3] 페이지 참고
+  */
+@deprecated
 object SessionizationUdf {
 
   private val SESSION_EXPIRED_TIME: Long = 30 * 60 * 1000L

--- a/src/test/scala/sessionization/SessionizationBuiltInTest.scala
+++ b/src/test/scala/sessionization/SessionizationBuiltInTest.scala
@@ -3,11 +3,11 @@ package sessionization
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, to_timestamp}
 import org.scalatest.flatspec.AnyFlatSpec
-import sessionization.SessionizationUdf.augmentSessionId
+import sessionization.SessionizationBuiltIn.augmentSessionId
 
 import java.sql.Timestamp
 
-class SessionizationUdfTest extends AnyFlatSpec {
+class SessionizationBuiltInTest extends AnyFlatSpec {
 
   val spark: SparkSession = SparkSession
     .builder()

--- a/src/test/scala/sessionization/SessionizationBuiltInTest.scala
+++ b/src/test/scala/sessionization/SessionizationBuiltInTest.scala
@@ -99,10 +99,8 @@ class SessionizationBuiltInTest extends AnyFlatSpec {
     ).toDF()
       .withColumn("date_hour", lit(processTime))
 
-    val value = augmentSessionId(data, processTime)
-    value.show(false)
     // when
-    val result = value.collect()
+    val result = augmentSessionId(data, processTime).collect()
 
     // then
     assert(result(0).getString(8) == result(2).getString(8))

--- a/src/test/scala/sessionization/SessionizationBuiltInTest.scala
+++ b/src/test/scala/sessionization/SessionizationBuiltInTest.scala
@@ -3,7 +3,7 @@ package sessionization
 import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.functions.{col, to_timestamp}
 import org.scalatest.flatspec.AnyFlatSpec
-import sessionization.SessionizationBuiltIn.augmentSessionId
+import sessionization.SessionizationBuiltIn.{augmentSessionId, loadPrevActiveSessions}
 
 import java.sql.Timestamp
 
@@ -168,5 +168,86 @@ class SessionizationBuiltInTest extends AnyFlatSpec {
     // then
     assert(result(0).getString(8) == result(1).getString(8))
     assert(result(1).getString(8) != result(2).getString(8))
+  }
+
+  "loadPrevActiveSessions" should "load sessions that are only active and take the last session only" in {
+    // given
+    val data = Seq(
+      SessionSchema(
+        "2023-10-15 00:29:00 UTC",
+        "click",
+        1,
+        101,
+        "electronics.smartphone",
+        "BrandA",
+        299.99,
+        1001,
+        "session1"
+      ),
+      SessionSchema(
+        "2023-10-15 00:40:00 UTC",
+        "click",
+        2,
+        102,
+        "electronics.tablet",
+        "BrandB",
+        399.99,
+        1002,
+        "session2"
+      ),
+      SessionSchema(
+        "2023-10-15 00:45:00 UTC",
+        "click",
+        2,
+        102,
+        "electronics.tablet",
+        "BrandB",
+        399.99,
+        1002,
+        "session2"
+      ),
+      SessionSchema(
+        "2023-10-15 00:50:00 UTC",
+        "click",
+        2,
+        102,
+        "electronics.tablet",
+        "BrandB",
+        399.99,
+        1003,
+        "session3"
+      )
+    ).toDF()
+    val expected = Seq(
+      SessionSchema(
+        "2023-10-15 00:45:00 UTC",
+        "click",
+        2,
+        102,
+        "electronics.tablet",
+        "BrandB",
+        399.99,
+        1002,
+        "session2"
+      ),
+      SessionSchema(
+        "2023-10-15 00:50:00 UTC",
+        "click",
+        2,
+        102,
+        "electronics.tablet",
+        "BrandB",
+        399.99,
+        1003,
+        "session3"
+      )
+    ).toDF()
+    val processTime = "2023-10-15T01Z"
+
+    // when
+    val result = loadPrevActiveSessions(data, processTime)
+
+    // then
+    assert(result.collect() sameElements expected.collect())
   }
 }


### PR DESCRIPTION
#4 - Sessionization 반영된 이전 데이터와 프로세싱 대상인 Behavior 로그에 대해 Continuous한 Sessionizaton을 구현하였습니다.

---

### 반영사항
- deprecate SessionizationUdf
- 이전 Sessionization 반영 데이터 Write
- event_time -> event_timestamp 추가 컬럼 설정하여 프로세싱
- 이전 Sessionization 반영 데이터 load 로직 구현
  - process 대상 시간의 이전 30분 이내 데이터
  - 중복 없도록 최근 세션 데이터만 선택
- Continuous Sessionization 구현
  - Active Session Id 만 그대로 가져오고, 그 이후 로직 동일
  - Sessionization 로직 이후 현재 Process 데이터만 가져오도록 필터링
- 시간 순서대로 데이터 sort 후 저장